### PR TITLE
minor cleanup

### DIFF
--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -3,11 +3,8 @@
   tasks:
   - name: All the libraries i love
     become: true
-    apt:
-      name: fzf
-      state: present
-    vars:
-      packages:
+    ansible.builtin.apt:
+      pkg:
       - fzf
       - ripgrep
       - pavucontrol
@@ -15,6 +12,3 @@
       - jq
       - tldr
       - shutter
-    loop_control:
-      loop_var: package
-    with_items: "{{ packages }}"

--- a/playbooks/i3.yml
+++ b/playbooks/i3.yml
@@ -11,13 +11,17 @@
         dest: /tmp/keyring.deb 
         checksum: sha256:f9bb4340b5ce0ded29b7e014ee9ce788006e9bbfe31e96c09b2118ab91fca734
 
-    - name: Return motd to registered var
+    - name: Install sur5r's i3wm signing key
       become: true
-      ansible.builtin.command: apt install /tmp/keyring.deb
+      ansible.builtin.apt:
+        deb: /tmp/keyring.deb
 
-    - name: Return motd to registered var
+    - name: Add sur5r's i3 repository into sources list
       become: true
-      ansible.builtin.command: echo "deb http://debian.sur5r.net/i3/ $(grep '^DISTRIB_CODENAME=' /etc/lsb-release | cut -f2 -d=) universe" | tee /etc/apt/sources.list.d/sur5r-i3.list
+      ansible.builtin.apt_repository:
+        repo: deb http://debian.sur5r.net/i3/ {{ ansible_distribution_release }} universe
+        state: present
+        filename: sur5r-i3
 
     - name: Install i3
       become: true

--- a/playbooks/zsh.yml
+++ b/playbooks/zsh.yml
@@ -1,12 +1,11 @@
 - hosts: localhost
   vars:
-    username: "theprimeagen"
-    email: "theprimeagen@gmail.com"
-    ssh_key_filename: "id_theprimeagen_rsa"
-    config: "{{ lookup('ansible.builtin.env', 'XDG_CONFIG') }}"
-    home: "{{ lookup('ansible.builtin.env', 'HOME') }}"
     zsh_dependencies: []
   tasks:
+  - name: Include main vars
+    ansible.builtin.include_vars:
+      file: vars.yml
+
   - name: Ensure Zsh with dependencies are installed
     apt:
       name: "{{ ['zsh'] + zsh_dependencies }}"
@@ -30,8 +29,7 @@
     register: ohmyzsh_result
     failed_when: "'FAILED' in ohmyzsh_result.stderr"
 
-  
-  # This is another one of the items i cannot seem to figure out.  I am using root but i am not getting this to change forever...
+  # For this to work you need to logout and in again. chsh edits the shell defined in /etc/passwd which is the login shell
   - name: sets default shell to zsh
     become: true
     ansible.builtin.command: chsh -s /usr/bin/zsh


### PR DESCRIPTION
I found myself in a similar situation with a fresh install of popos, though due to a failed kernel update forcing me to reinstall from scratch. (turns out that was just a a skill issue and the new kernel not supporting my graphics card) 

## i3.yml

- sur5r provides their key as a deb, so can't improve the download, if they provided it as a gpg key, we could use the `apt_key` built in
- use the built in `apt` command for installing the deb file 
- use the built in `apt_repository` for added the repository
- use the ansible variable `ansible_distribution_release` to fetch the distribution release name

## zsh.yml

- use vars.yml file for variables
- update comment on change shell task

## common.yml

- replace apt,  with `ansible.builtin.apt`
- replace loop (not working), with `pkg`, which takes a list of packages