### PR TITLE
Update dev to Fix installation script for LuaRocks to ensure correct …

### DIFF
--- a/runs/dev
+++ b/runs/dev
@@ -10,10 +10,10 @@ cargo install stylua
 # luarocks
 pushd /tmp/luarocks-3.11.0
 (
-    wget --output-document /tmp/luarocks.tar.gz https://luarocks.org/releases/luarocks-3.11.0.tar.gz
-    tar zxpf /tmp/luarocks.tar.gz -C /tmp
-    cd
-    ./configure && make && sudo make install
+  wget --output-document /tmp/luarocks.tar.gz https://luarocks.org/releases/luarocks-3.11.0.tar.gz
+tar zxpf /tmp/luarocks.tar.gz -C /tmp
+cd /tmp/luarocks-3.11.0  
+./configure && make && sudo make install
 )
 popd
 


### PR DESCRIPTION
…directory navigation

The original installation script had an issue where the `cd` command was not specifying the correct directory after extracting the LuaRocks archive. This caused the `./configure` step to fail. 

This change ensures the script correctly navigates to the extracted directory before running the installation commands. Now, the script explicitly changes to the correct directory `/tmp/luarocks-3.11.0` before executing `./configure && make && sudo make install`.