### PR TITLE
Fix: transparent blur window for ghostty

### DIFF
--- a/env/.config/ghostty/config
+++ b/env/.config/ghostty/config
@@ -2,8 +2,8 @@
 
 theme = rose-pine-moon
 background = 000000
-background-opacity = 0.85
-background-blur = false
+#background-opacity = 0.85
+#background-blur = false
 
 shell-integration-features = no-cursor,no-sudo,no-title
 gtk-titlebar = false

--- a/env/.config/hypr/hyprland.conf
+++ b/env/.config/hypr/hyprland.conf
@@ -282,6 +282,9 @@ bindl = , XF86AudioPrev, exec, playerctl previous
 # Ignore maximize requests from apps. You'll probably like this.
 windowrule = suppressevent maximize, class:.*
 
+# Transparent Blur for workspace 4 -- usually where my terminal resides
+windowrule = opacity 0.75,workspace:4 # Looks much better when using telescope to search
+
 # Fix some dragging issues with XWayland
 windowrule = nofocus,class:^$,title:^$,xwayland:1,floating:1,fullscreen:0,pinned:0
 


### PR DESCRIPTION
It just makes all the windows at workspace 4 transparent and blur.